### PR TITLE
BendFix: Shape bend fix

### DIFF
--- a/lib/src/Data/VertexType.dart
+++ b/lib/src/Data/VertexType.dart
@@ -84,7 +84,7 @@ class VertexType {
     if (this.has(Clr3))    result += 3;
     if (this.has(Clr4))    result += 4;
     if (this.has(Weight))  result += 1;
-    if (this.has(Bending)) result += 1;
+    if (this.has(Bending)) result += 4;
     return result;
   }
 
@@ -209,7 +209,7 @@ class VertexType {
     }
     if (this.has(Bending)) {
       if (type == Bending) return result;
-      result += 1;
+      result += 4;
     }
     return -1;
   }

--- a/lib/src/Shaders/MaterialLightConfig.dart
+++ b/lib/src/Shaders/MaterialLightConfig.dart
@@ -278,7 +278,7 @@ class MaterialLightConfig {
     buf.writeln("{");
     buf.writeln("   if(bendVal >= 0.0)");
     buf.writeln("   {");
-    buf.writeln("      int index = int(floor(bendVal));");
+    buf.writeln("      int index = int(floor(bendVal))/2;");
     buf.writeln("      if(index < bendMatCount)");
     buf.writeln("      {");
     buf.writeln("         float weight = 1.0 - bendVal + float(index);");
@@ -307,6 +307,10 @@ class MaterialLightConfig {
     buf.writeln("      bendPos += posAttr*weight;");
     if (this.norm) buf.writeln("      bendNorm += normAttr*weight;");
     if (this.binm) buf.writeln("      bendBinm += binmAttr*weight;");
+    buf.writeln("   }");
+    buf.writeln("   else");
+    buf.writeln("   {");
+    buf.writeln("      bendPos = bendPos/weightSum;");
     buf.writeln("   }");
     if (this.norm) buf.writeln("   bendNorm = normalize(bendNorm);");
     if (this.binm) buf.writeln("   bendBinm = normalize(bendBinm);");

--- a/lib/src/Shaders/MaterialLightConfig.dart
+++ b/lib/src/Shaders/MaterialLightConfig.dart
@@ -278,10 +278,10 @@ class MaterialLightConfig {
     buf.writeln("{");
     buf.writeln("   if(bendVal >= 0.0)");
     buf.writeln("   {");
-    buf.writeln("      int index = int(floor(bendVal))/2;");
+    buf.writeln("      int index = int(floor((bendVal + 0.5)*0.5));");
     buf.writeln("      if(index < bendMatCount)");
     buf.writeln("      {");
-    buf.writeln("         float weight = 1.0 - bendVal + float(index);");
+    buf.writeln("         float weight = clamp(bendVal - float(index)*2.0, 0.0, 1.0);");
     buf.writeln("         mat4 m = bendValues[index].mat;");
     buf.writeln("         weightSum += weight;");
     buf.writeln("         bendPos += (m*vec4(posAttr, 1.0)).xyz*weight;");

--- a/lib/src/Shaders/MaterialLightConfig.dart
+++ b/lib/src/Shaders/MaterialLightConfig.dart
@@ -281,7 +281,7 @@ class MaterialLightConfig {
     buf.writeln("      int index = int(floor(bendVal));");
     buf.writeln("      if(index < bendMatCount)");
     buf.writeln("      {");
-    buf.writeln("         float weight = bendVal - float(index);");
+    buf.writeln("         float weight = 1.0 - bendVal + float(index);");
     buf.writeln("         mat4 m = bendValues[index].mat;");
     buf.writeln("         weightSum += weight;");
     buf.writeln("         bendPos += (m*vec4(posAttr, 1.0)).xyz*weight;");

--- a/lib/src/Shapes/ShapeBuilders.dart
+++ b/lib/src/Shapes/ShapeBuilders.dart
@@ -117,9 +117,8 @@ void _addCuboidSide(Shape shape, Data.VertexType type, ver2Handle vertexHndl,
     ver.location = new Math.Point3.fromVector3(vec7);
     ver.textureCube = vec7.normal();
 
-    Math.Vector4 vecB = new Math.Vector4(u*v, (1.0-u)*v, u*(1.0-v), (1.0-u)*(1.0-v));
-    vecB = vecB.normal()*scalar;
-    ver.bending = new Math.Point4(index1-vecB.dx, index2-vecB.dy, index4-vecB.dz, index3-vecB.dw);
+    Math.Vector4 vecB = new Math.Vector4(u*v, (1.0-u)*v, u*(1.0-v), (1.0-u)*(1.0-v))*scalar;
+    ver.bending = new Math.Point4(index3-vecB.dx, index4-vecB.dy, index2-vecB.dz, index1-vecB.dw);
     if (vertexHndl != null) vertexHndl(ver, u, v);
   }, type);
   if (face != null) shape.merge(face);

--- a/lib/src/Shapes/ShapeBuilders.dart
+++ b/lib/src/Shapes/ShapeBuilders.dart
@@ -119,12 +119,10 @@ void _addCuboidSide(Shape shape, Data.VertexType type, ver2Handle vertexHndl,
 
     Math.Vector4 vecB = new Math.Vector4(u*v, (1.0-u)*v, u*(1.0-v), (1.0-u)*(1.0-v));
     vecB = vecB.normal()*scalar;
-    ver.bending = new Math.Point4(index1-vecB.dx, index2-vecB.dy, index3-vecB.dz, index4-vecB.dw);
+    ver.bending = new Math.Point4(index1-vecB.dx, index2-vecB.dy, index4-vecB.dz, index3-vecB.dw);
     if (vertexHndl != null) vertexHndl(ver, u, v);
   }, type);
   if (face != null) shape.merge(face);
-
-  print(shape.toString());
 }
 
 /// Creates a disk shape.

--- a/lib/src/Shapes/ShapeBuilders.dart
+++ b/lib/src/Shapes/ShapeBuilders.dart
@@ -127,7 +127,8 @@ void _addCuboidSide(Shape shape, Data.VertexType type, ver2Handle vertexHndl,
 /// Creates a disk shape.
 /// [sides] is the number of division on the side, and [height] is the y offset of the disk.
 /// [flip] will flip the disk over, and [radiusHndl] is a handle for custom variant radius.
-Shape disk({int sides: 8, double height: 0.0, bool flip: false, func1Handle radiusHndl: null}) {
+Shape disk({int sides: 8, double height: 0.0, bool flip: false,
+    double bending: -1.0, func1Handle radiusHndl: null}) {
   if (radiusHndl == null) radiusHndl = (double a) => 1.0;
   if (sides < 3) return null;
   Shape shape = new Shape();
@@ -139,7 +140,8 @@ Shape disk({int sides: 8, double height: 0.0, bool flip: false, func1Handle radi
     norm:    new Math.Vector3(0.0, 0.0, sign),
     txt2D:   new Math.Point2(0.5, 0.5),
     txtCube: new Math.Vector3(0.0, 0.0, sign).normal(),
-    clr:     new Math.Color4(1.0, 1.0, 1.0)));
+    clr:     new Math.Color4(1.0, 1.0, 1.0),
+    bending: new Math.Point4(bending, -1.0, -1.0, -1.0)));
   for (int i = 0; i <= sides; i++) {
     double angle = step*i.toDouble();
     double x = sign*sin(angle), y = cos(angle);
@@ -149,7 +151,8 @@ Shape disk({int sides: 8, double height: 0.0, bool flip: false, func1Handle radi
       norm:    new Math.Vector3(0.0, 0.0, sign),
       txt2D:   new Math.Point2(x*0.5+0.5, y*0.5+0.5),
       txtCube: new Math.Vector3(x, y, sign).normal(),
-      clr:     new Math.Color4(x, y, y)));
+      clr:     new Math.Color4(x, y, y),
+      bending: new Math.Point4(bending, -1.0, -1.0, -1.0)));
   }
   shape.faces.addFan(vers);
   return shape;
@@ -182,17 +185,18 @@ Shape cylindrical({func2Handle radiusHndl: null, int sides: 8, int div: 1, bool 
     double radius = radiusHndl(u, v);
     ver.location = new Math.Point3(x*radius, y*radius, z);
     ver.textureCube = new Math.Vector3(x*radius, y*radius, z).normal();
+    ver.bending = new Math.Point4(0.9999*(1.0-v), 1.0 + 0.9999*v, -1.0, -1.0);
   });
   if (shape == null) return null;
   shape.calculateNormals();
   shape.adjustNormals();
   if (capTop) {
-    Shape top = disk(sides: sides, height: 1.0, flip: false,
+    Shape top = disk(sides: sides, height: 1.0, flip: false, bending: 0.0,
       radiusHndl: (double u) => radiusHndl(u, 1.0));
     shape.merge(top);
   }
   if (capBottom) {
-    Shape bottom = disk(sides: sides, height: -1.0, flip: true,
+    Shape bottom = disk(sides: sides, height: -1.0, flip: true, bending: 1.0,
       radiusHndl: (double u) => radiusHndl(1.0-u, 0.0));
     shape.merge(bottom);
   }
@@ -376,6 +380,8 @@ Shape grid({int widthDiv: 4, int heightDiv: 4, func2Handle heightHndl: null}) {
     double y = v*2.0-1.0;
     ver.location = new Math.Point3(x, y, heightHndl(u, v));
     ver.textureCube = new Math.Vector3(x, y, 1.0).normal();
+    ver.bending = new Math.Point4(u*v*0.9999, 1.0 + (1.0-u)*v*0.9999,
+      3.0 + u*(1.0-v)*0.9999, 2.0 + (1.0-u)*(1.0-v)*0.9999);
   });
 }
 

--- a/lib/src/Shapes/Vertex.dart
+++ b/lib/src/Shapes/Vertex.dart
@@ -184,7 +184,7 @@ class Vertex {
     } else if (type == Data.VertexType.Weight) {
       return [ this._weight ];
     } else if (type == Data.VertexType.Bending) {
-      if (this._bending == null) return [0.0, 0.0, 0.0, 0.0];
+      if (this._bending == null) return [-1.0, -1.0, -1.0, -1.0];
       else return this._bending.toList();
     } else return [];
   }

--- a/lib/src/Techniques/Inspection.dart
+++ b/lib/src/Techniques/Inspection.dart
@@ -29,10 +29,7 @@ class Inspection extends Technique {
   bool _showWeight;
   bool _showAxis;
   bool _showAABB;
-  bool _showBend1;
-  bool _showBend2;
-  bool _showBend3;
-  bool _showBend4;
+  bool _showBend;
   double _vectorScale;
 
   /// Creates a new inspection techinque.
@@ -64,10 +61,7 @@ class Inspection extends Technique {
     this._showWeight         = false;
     this._showAxis           = false;
     this._showAABB           = false;
-    this._showBend1          = false;
-    this._showBend2          = false;
-    this._showBend3          = false;
-    this._showBend4          = false;
+    this._showBend           = false;
     this._vectorScale        = 1.0;
   }
 
@@ -136,20 +130,8 @@ class Inspection extends Technique {
   bool get showAABB => this._showAABB;
 
   /// Indicates if the first bend should be showed.
-  set showBend1(bool show) => this._showBend1 = show;
-  bool get showBend1 => this._showBend1;
-
-  /// Indicates if the second bend should be showed.
-  set showBend2(bool show) => this._showBend2 = show;
-  bool get showBend2 => this._showBend2;
-
-  /// Indicates if the third bend should be showed.
-  set showBend3(bool show) => this._showBend3 = show;
-  bool get showBend3 => this._showBend3;
-
-  /// Indicates if the fourth bend should be showed.
-  set showBend4(bool show) => this._showBend4 = show;
-  bool get showBend4 => this._showBend4;
+  set showBend(bool show) => this._showBend = show;
+  bool get showBend => this._showBend;
 
   /// The scalar to apply to vectors lengths.
   /// To make the vectors change length the cache also has to be cleared.
@@ -202,14 +184,8 @@ class Inspection extends Technique {
         this._render(state, store, obj.shape, 'txt2DColor', this._txt2DColor, this._ambient3, this._diffuse3);
       if (this._showWeight)
         this._render(state, store, obj.shape, 'weight', this._weight, this._ambient3, this._diffuse3);
-      if (this._showBend1)
-        this._render(state, store, obj.shape, 'bend1', this._bend1Fill, this._ambient3, this._diffuse3);
-      if (this._showBend2)
-        this._render(state, store, obj.shape, 'bend2', this._bend2Fill, this._ambient3, this._diffuse3);
-      if (this._showBend3)
-        this._render(state, store, obj.shape, 'bend3', this._bend3Fill, this._ambient3, this._diffuse3);
-      if (this._showBend4)
-        this._render(state, store, obj.shape, 'bend4', this._bend4Fill, this._ambient3, this._diffuse3);
+      if (this._showBend)
+        this._render(state, store, obj.shape, 'bend1', this._bendFill, this._ambient3, this._diffuse3);
 
       state.gl.disable(WebGL.DEPTH_TEST);
       state.gl.enable(WebGL.BLEND);
@@ -529,26 +505,7 @@ class Inspection extends Technique {
     return result;
   }
 
-  /// Convertes the given [shape] into the bend 1 color shape.
-  Shapes.Shape _bend1Fill(Shapes.Shape shape) {
-    return this._bendFill(shape, (Math.Point4 bend) => bend.x);
-  }
-
-  /// Convertes the given [shape] into the bend 2 color shape.
-  Shapes.Shape _bend2Fill(Shapes.Shape shape) {
-    return this._bendFill(shape, (Math.Point4 bend) => bend.y);
-  }
-
-  /// Convertes the given [shape] into the bend 3 color shape.
-  Shapes.Shape _bend3Fill(Shapes.Shape shape) {
-    return this._bendFill(shape, (Math.Point4 bend) => bend.z);
-  }
-
-  /// Convertes the given [shape] into the bend 4 color shape.
-  Shapes.Shape _bend4Fill(Shapes.Shape shape) {
-    return this._bendFill(shape, (Math.Point4 bend) => bend.w);
-  }
-
+  /// Gets the maximum bend index of the given [shape].
   int _maxIndex(Shapes.Shape shape) {
     double maxBend = 0.0;
     shape.vertices.forEach((Shapes.Vertex vertex) {
@@ -562,6 +519,7 @@ class Inspection extends Technique {
     return maxBend.floor()+1;
   }
 
+  /// Gets the spectrum color for the [bendVal] in the [maxIndex] range.
   Math.Color3 _bendColor(double bendVal, int maxIndex) {
     if (bendVal < 0.0) {
       return new Math.Color3.black();
@@ -572,15 +530,18 @@ class Inspection extends Technique {
     }
   }
 
-  /// Convertes the given [shape] into one of the bend color shapes.
-  Shapes.Shape _bendFill(Shapes.Shape shape, double hndl(Math.Point4 bend)) {
+  /// Convertes the given [shape] into the bend color shape.
+  Shapes.Shape _bendFill(Shapes.Shape shape) {
     int maxIndex = this._maxIndex(shape);
     Shapes.Shape result = new Shapes.Shape();
     shape.vertices.forEach((Shapes.Vertex vertex) {
       Math.Point4 bend = vertex.bending;
       if (bend == null) bend = new Math.Point4.zero();
-      double bendVal = hndl(bend);
-      Math.Color3 clr = this._bendColor(bendVal, maxIndex);
+      Math.Color3 clr = new Math.Color3.black();
+      clr = clr + this._bendColor(bend.x, maxIndex);
+      clr = clr + this._bendColor(bend.y, maxIndex);
+      clr = clr + this._bendColor(bend.z, maxIndex);
+      clr = clr + this._bendColor(bend.w, maxIndex);
       result.vertices.add(vertex.copy()
         ..binormal = new Math.Vector3.zero()
         ..color = new Math.Color4.fromColor3(clr));

--- a/lib/src/Techniques/Inspection.dart
+++ b/lib/src/Techniques/Inspection.dart
@@ -516,7 +516,7 @@ class Inspection extends Technique {
       maxBend = math.max(maxBend, bend.z);
       maxBend = math.max(maxBend, bend.w);
     });
-    return maxBend.floor()+1;
+    return ((maxBend + 1.5)*0.5).floor();
   }
 
   /// Gets the spectrum color for the [bendVal] in the [maxIndex] range.
@@ -524,9 +524,9 @@ class Inspection extends Technique {
     if (bendVal < 0.0) {
       return new Math.Color3.black();
     } else {
-      double index = bendVal.floor().toDouble();
-      double value = 1.0 - (bendVal - index.toDouble());
-      return new Math.Color3.fromHVS(index/maxIndex.toDouble(), value, 1.0);
+      double index = ((bendVal + 0.5)*0.5).floorToDouble();
+      double value = (bendVal - index*2.0);
+      return new Math.Color3.fromHVS(index/maxIndex, value, 1.0);
     }
   }
 

--- a/test/test002/test.dart
+++ b/test/test002/test.dart
@@ -52,10 +52,7 @@ void main() {
     ..add("Textures2D",      (bool show) { tech.showTxt2DColor     = show; })
     ..add("TexturesCube",    (bool show) { tech.showTxtCube        = show; })
     ..add("Weight",          (bool show) { tech.showWeight         = show; })
-    ..add("Bend1",           (bool show) { tech.showBend1          = show; })
-    ..add("Bend2",           (bool show) { tech.showBend2          = show; })
-    ..add("Bend3",           (bool show) { tech.showBend3          = show; })
-    ..add("Bend4",           (bool show) { tech.showBend4          = show; })
+    ..add("Bend",            (bool show) { tech.showBend           = show; })
     ..add("Axis",            (bool show) { tech.showAxis           = show; }, true)
     ..add("AABB",            (bool show) { tech.showAABB           = show; });
 

--- a/test/test035/test.dart
+++ b/test/test035/test.dart
@@ -4,6 +4,7 @@
 library ThreeDart.test.test035;
 
 import 'dart:html';
+import 'dart:math';
 
 import 'package:ThreeDart/ThreeDart.dart' as ThreeDart;
 import 'package:ThreeDart/Shapes.dart' as Shapes;
@@ -16,7 +17,8 @@ import '../common/common.dart' as common;
 
 void main() {
   common.shellTest("Test 035", ["shapes"],
-    "A test of the bending a shape with the Material Light Shader.");
+    "A test of the bending a shape with the Material Light Shader. "+
+    "Not all of the shapes have predefined bend values.");
 
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("threeDart");
 
@@ -33,7 +35,12 @@ void main() {
     ..specular.shininess = 10.0
     ..bendMatrices.add(new Math.Matrix4.identity())
     ..bendMatrices.add(new Math.Matrix4.identity())
-    ;
+    ..bendMatrices.add(new Math.Matrix4.identity())
+    ..bendMatrices.add(new Math.Matrix4.identity())
+    ..bendMatrices.add(new Math.Matrix4.identity())
+    ..bendMatrices.add(new Math.Matrix4.identity())
+    ..bendMatrices.add(new Math.Matrix4.identity())
+    ..bendMatrices.add(new Math.Matrix4.identity());
 
   Movers.Group camMover = new Movers.Group()
     ..add(new Movers.UserRotater(input: td.userInput))
@@ -42,13 +49,17 @@ void main() {
     ..add(new Movers.Constant(new Math.Matrix4.translate(0.0, 0.0, 5.0)));
 
   Movers.Mover mover1 = new Movers.Group()
+    ..add(new Movers.Constant(new Math.Matrix4.translate(0.5, 0.0, 0.0)))
+    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: 1.7))
+    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.5, deltaRoll: 0.0))
+    ..add(new Movers.Constant(new Math.Matrix4.rotateX(0.35)))
+    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: -0.5, deltaRoll: 0.0))
     ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: -1.7))
-    ..add(new Movers.Constant(new Math.Matrix4.translate(0.25, 0.0, 0.0)))
-    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: 1.7));
+    ..add(new Movers.Constant(new Math.Matrix4.translate(-0.5, 0.0, 0.0)));
 
   Movers.Mover mover2 = new Movers.Group()
     ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: -1.4))
-    ..add(new Movers.Constant(new Math.Matrix4.translate(0.25, 0.0, 0.0)))
+    ..add(new Movers.Constant(new Math.Matrix4.translate(0.5, 0.0, 0.0)))
     ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: 1.4));
 
   Scenes.EntityPass pass = new Scenes.EntityPass()
@@ -56,26 +67,18 @@ void main() {
     ..children.add(obj)
     ..camera.mover = camMover
     ..onPreUpdate.add((ThreeDart.StateEventArgs args) {
-      tech.bendMatrices[0] = mover1.update(args.state, null);
-      tech.bendMatrices[1] = mover2.update(args.state, null);
+      Math.Matrix4 mat1 = mover1.update(args.state, null);
+      Math.Matrix4 mat2 = mover2.update(args.state, null);
+      tech.bendMatrices[0] = mat1;
+      tech.bendMatrices[1] = mat2;
+      tech.bendMatrices[2] = mat1;
+      tech.bendMatrices[3] = mat2;
+      tech.bendMatrices[4] = mat1;
+      tech.bendMatrices[5] = mat2;
+      tech.bendMatrices[6] = mat1;
+      tech.bendMatrices[7] = mat2;
     });
   td.scene = pass;
-
-  // Techniques.Inspection inspTech = new Techniques.Inspection()
-  //   ..showWireFrame = true
-  //   ..showAxis = true;
-  //
-  // Shapes.Shape inspShap = Shapes.cube()
-  //   ..applyPositionMatrix(new Math.Matrix4.scale(0.1, 0.1, 0.1));
-  //
-  // pass.children.add(new ThreeDart.Entity(
-  //   mover: new Movers.Constant(), shape: inspShap, tech: inspTech));
-  //
-  // pass.children.add(new ThreeDart.Entity(
-  //   mover: mover1, shape: inspShap, tech: inspTech));
-  //
-  // pass.children.add(new ThreeDart.Entity(
-  //   mover: mover2, shape: inspShap, tech: inspTech));
 
   void setShape(Shapes.Shape shape) {
     shape.calculateNormals();
@@ -88,7 +91,8 @@ void main() {
     ..add("Cone",     () { setShape(Shapes.cylinder(topRadius: 0.0, sides: 12, capTop: false, div: 30)); })
     ..add("Sphere",   () { setShape(Shapes.sphere(widthDiv: 20, heightDiv: 20)); })
     ..add("Toroid",   () { setShape(Shapes.toroid(minorRadius: 0.25, majorRadius: 1.5)); })
-    ..add("Knot",     () { setShape(Shapes.knot(minorRadius: 0.1)); });
+    ..add("Knot",     () { setShape(Shapes.knot(minorRadius: 0.1)); })
+    ..add("Grid",     () { setShape(Shapes.grid()); });
 
   var update;
   update = (num t) {

--- a/test/test035/test.dart
+++ b/test/test035/test.dart
@@ -33,7 +33,7 @@ void main() {
     ..specular.shininess = 10.0
     ..bendMatrices.add(new Math.Matrix4.identity())
     ..bendMatrices.add(new Math.Matrix4.identity())
-    ..bendMatrices.add(new Math.Matrix4.identity());
+    ;
 
   Movers.Group camMover = new Movers.Group()
     ..add(new Movers.UserRotater(input: td.userInput))
@@ -42,13 +42,13 @@ void main() {
     ..add(new Movers.Constant(new Math.Matrix4.translate(0.0, 0.0, 5.0)));
 
   Movers.Mover mover1 = new Movers.Group()
-    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: -0.7))
-    ..add(new Movers.Constant(new Math.Matrix4.translate(0.5, 0.0, 0.0)))
-    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: 0.7));
+    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: -1.7))
+    ..add(new Movers.Constant(new Math.Matrix4.translate(0.25, 0.0, 0.0)))
+    ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: 1.7));
 
   Movers.Mover mover2 = new Movers.Group()
     ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: -1.4))
-    ..add(new Movers.Constant(new Math.Matrix4.translate(0.5, 0.0, 0.0)))
+    ..add(new Movers.Constant(new Math.Matrix4.translate(0.25, 0.0, 0.0)))
     ..add(new Movers.Rotater(deltaYaw: 0.0, deltaPitch: 0.0, deltaRoll: 1.4));
 
   Scenes.EntityPass pass = new Scenes.EntityPass()
@@ -58,7 +58,6 @@ void main() {
     ..onPreUpdate.add((ThreeDart.StateEventArgs args) {
       tech.bendMatrices[0] = mover1.update(args.state, null);
       tech.bendMatrices[1] = mover2.update(args.state, null);
-      tech.bendMatrices[2] = new Math.Matrix4.identity();
     });
   td.scene = pass;
 
@@ -80,7 +79,6 @@ void main() {
 
   void setShape(Shapes.Shape shape) {
     shape.calculateNormals();
-    shape.applyPositionMatrix(new Math.Matrix4.scale(0.25, 0.25, 2.0));
     obj.shape = shape;
   }
 

--- a/test/test035/test.dart
+++ b/test/test035/test.dart
@@ -85,8 +85,8 @@ void main() {
   }
 
   new common.RadioGroup("shapes")
-    ..add("Cuboid",   () { setShape(Shapes.cuboid(widthDiv: 30, heightDiv: 30)); })
-    ..add("Cylinder", () { setShape(Shapes.cylinder(div: 100, sides: 20)); }, true)
+    ..add("Cuboid",   () { setShape(Shapes.cuboid(widthDiv: 30, heightDiv: 30)); }, true)
+    ..add("Cylinder", () { setShape(Shapes.cylinder(div: 100, sides: 20)); })
     ..add("Cone",     () { setShape(Shapes.cylinder(topRadius: 0.0, sides: 12, capTop: false, div: 30)); })
     ..add("Sphere",   () { setShape(Shapes.sphere(widthDiv: 20, heightDiv: 20)); })
     ..add("Toroid",   () { setShape(Shapes.toroid(minorRadius: 0.25, majorRadius: 1.5)); })


### PR DESCRIPTION
### [Issue 11](https://github.com/Grant-Nelson/ThreeDart/issues/11)
Finish transition the bend from a single indexed value to the multi-indexed values for providing better shape bending. Need to implement default generation of bending values for each shape. Also need to update MaterialLight and test035 to use and test shape bending. 

### Implementation
- Used a Point4 to provide 4 bend indices.
- Each index is  from 2*n to 2*n+1, for example for transitioning from no bend matrix to bend matrix 3, the values will change from 6.0 to 7.0.
- To not use any bend matrix use -1.0.
- Typically the sum of the weights of the four indices should add up to 1.0 such as 2.24, 4.75, -1.0, -1.0 will be 25% matrix 1 and 75% matrix 2.

### +10 / QA
Check updates to test035 to see it feels right.

### Unit-tests
No unit-tests, but test035 was update.