### PR TITLE
Fix back buffers

### DIFF
--- a/lib/src/Core/Core.dart
+++ b/lib/src/Core/Core.dart
@@ -2,6 +2,7 @@ library ThreeDart.Core;
 
 import 'dart:web_gl' as WebGL;
 import 'dart:html' as html;
+import 'dart:async';
 
 import '../Collections/Collections.dart' as Collections;
 import '../Data/Data.dart' as Data;

--- a/lib/src/Core/ThreeDart.dart
+++ b/lib/src/Core/ThreeDart.dart
@@ -175,8 +175,6 @@ class ThreeDart implements Events.Changable {
     return fps;
   }
 
-  /// TODO: Somehow need to detect the size change of the canvas and call a render.
-
   /// Makes sure the size of the canvas is correctly set.
   void _resize() {
     // Lookup the size the browser is displaying the canvas in CSS pixels and
@@ -191,6 +189,7 @@ class ThreeDart implements Events.Changable {
       this._canvas.width  = displayWidth;
       this._canvas.height = displayHeight;
     }
+    Timer.run(this.requestRender);
   }
 
   /// Requests a render to start the next time the main message loop

--- a/lib/src/Input/UserInput.dart
+++ b/lib/src/Input/UserInput.dart
@@ -121,7 +121,14 @@ class UserInput {
     new Button(msEvent.buttons, ctrl: msEvent.ctrlKey||msEvent.metaKey, alt: msEvent.altKey, shift: msEvent.shiftKey);
 
   /// Determines if the given mouse location is containerd in the canvas.
-  bool _mouseContained(html.MouseEvent msEvent) => this._elem.client.containsPoint(msEvent.client);
+  bool _mouseContained(html.MouseEvent msEvent) {
+    html.Rectangle rect = this._elem.getBoundingClientRect();
+    final int x = msEvent.page.x - rect.left;
+    if (x < 0) return false;
+    final int y = msEvent.page.y - rect.top;
+    if (y < 0) return false;
+    return (x < rect.width) && (y < rect.height);
+  }
 
   /// Handles focus of the canvas.
   void _onFocus(html.Event _) {
@@ -134,8 +141,9 @@ class UserInput {
   }
 
   /// Handles cancelling the content menu for the canvas.
-  void _onContentMenu(html.Event e) {
-    if (this.hasFocus) e.preventDefault();
+  void _onContentMenu(html.MouseEvent msEvent) {
+    if (this.hasFocus && this._mouseContained(msEvent))
+      msEvent.preventDefault();
   }
 
   /// Handles a keyboard key being released.
@@ -290,7 +298,7 @@ class UserInput {
   // Handles touch screen point presses starting on the canvas.
   void _onTouchStart(html.TouchEvent tEvent) {
     this._elem.focus();
-    this._focused = true; // This is here because focus/blur doesn't work right now.
+    this._focused = true; // TODO: Fix focus. This is here because focus/blur doesn't work right now.
 
     this._setTouchModifiers(tEvent);
     final List<Math.Point2> pnts = this._rawTouchPoints(tEvent);

--- a/lib/src/Scenes/CoverPass.dart
+++ b/lib/src/Scenes/CoverPass.dart
@@ -31,7 +31,6 @@ class CoverPass implements RenderPass {
     this.camera    = camera;
     this.target    = target;
     this.technique = tech;
-    // TODO: Replace shape with a shape builder.
     this._box      = new Core.Entity()
       ..shape      = Shapes.square();
     this._onRender = null;

--- a/lib/src/Scenes/Sterioscopic.dart
+++ b/lib/src/Scenes/Sterioscopic.dart
@@ -192,6 +192,6 @@ class Sterioscopic implements Scene {
     }
 
     Core.StateEventArgs args = new Core.StateEventArgs(this, state);
-    this._onRender.emit(args);
+    this._onRender?.emit(args);
   }
 }

--- a/web/resources/styles.css
+++ b/web/resources/styles.css
@@ -268,8 +268,7 @@ body {
   width: 100%;
   height: 100%;
   display: inline-block;
-  margin-left: 20px;
-  margin-bottom: 10px;
+  margin: 0px 0px 0px 0px;
   border: 1px solid #888;
 }
 
@@ -281,7 +280,6 @@ body {
   width: 100%;
   height: 100%;
   display: inline-block;
-  margin-left: 20px;
-  margin-bottom: 10px;
+  margin: 0px 0px 0px 0px;
   border: 1px solid #888;
 }

--- a/web/tests/test028/test.dart
+++ b/web/tests/test028/test.dart
@@ -57,7 +57,7 @@ void main() {
     ..specular.shininess = 10.0
     ..bump.textureCube = td.textureLoader.loadCubeFromPath("../resources/diceBumpMap");
 
-  Views.BackTarget colorTarget = new Views.BackTarget(800, 600)
+  Views.BackTarget colorTarget = new Views.BackTarget(800, 600, autoResize: true)
     ..clearColor = false;
 
   Scenes.CoverPass skybox = new Scenes.CoverPass.skybox(
@@ -71,7 +71,7 @@ void main() {
     ..technique = colorTech
     ..children.add(group);
 
-  Views.BackTarget depthTarget = new Views.BackTarget(400, 300);
+  Views.BackTarget depthTarget = new Views.BackTarget(400, 300, autoResize: true, autoResizeScalar: 0.5);
   Scenes.EntityPass depthPass = new Scenes.EntityPass()
     ..camera = userCamera
     ..target = depthTarget
@@ -97,7 +97,6 @@ void main() {
     ..target = new Views.FrontTarget(clearColor: false)
     ..technique = layoutTech;
 
-  // TODO: Fix aspect ratio problem
   td.scene = new Scenes.Compound(passes: [skybox, colorPass, depthPass, blurPass, layout]);
 
   common.showFPS(td);

--- a/web/tests/test029/test.dart
+++ b/web/tests/test029/test.dart
@@ -26,7 +26,7 @@ void main() {
     ..add(new Movers.Constant.translate(0.0, 0.0, 5.0));
   Views.Perspective userCamera = new Views.Perspective(mover: mover);
 
-  Views.BackTarget colorTarget = new Views.BackTarget(800, 600)
+  Views.BackTarget colorTarget = new Views.BackTarget(800, 600, autoResize: true)
     ..clearColor = false;
 
   ThreeDart.Entity obj = new ThreeDart.Entity()

--- a/web/tests/test029/test.dart
+++ b/web/tests/test029/test.dart
@@ -19,12 +19,12 @@ void main() {
 
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("testCanvas");
 
-  Movers.Group secondMover = new Movers.Group()
+  Movers.Group mover = new Movers.Group()
     ..add(new Movers.UserRotater(input: td.userInput))
     ..add(new Movers.UserRoller(ctrl: true, input: td.userInput))
     ..add(new Movers.UserZoom(input: td.userInput))
     ..add(new Movers.Constant.translate(0.0, 0.0, 5.0));
-  Views.Perspective userCamera = new Views.Perspective(mover: secondMover);
+  Views.Perspective userCamera = new Views.Perspective(mover: mover);
 
   Views.BackTarget colorTarget = new Views.BackTarget(800, 600)
     ..clearColor = false;

--- a/web/tests/test031/test.dart
+++ b/web/tests/test031/test.dart
@@ -31,7 +31,7 @@ void main() {
   Techniques.Normal normalTech = new Techniques.Normal()
     ..bumpyTextureCube = td.textureLoader.loadCubeFromPath("../resources/diceBumpMap");
 
-  Views.BackTarget normalTarget = new Views.BackTarget(800, 600)
+  Views.BackTarget normalTarget = new Views.BackTarget(800, 600, autoResize: true)
     ..color = new Math.Color4(0.5, 0.5, 1.0, 1.0);
 
   Scenes.EntityPass normalPass = new Scenes.EntityPass()
@@ -46,7 +46,7 @@ void main() {
   ..add(new Movers.Constant.translate(0.0, 0.0, 5.0));
   Views.Perspective userCamera = new Views.Perspective(mover: secondMover);
 
-  Views.BackTarget colorTarget = new Views.BackTarget(800, 600)
+  Views.BackTarget colorTarget = new Views.BackTarget(800, 600, autoResize: true)
     ..clearColor = false;
 
   ThreeDart.Entity colorObj = new ThreeDart.Entity()

--- a/web/tests/test033/test.dart
+++ b/web/tests/test033/test.dart
@@ -16,8 +16,6 @@ void main() {
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of a sterioscopic scene."]);
 
-  // TODO: Fix null emit error
-
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("testCanvas");
 
   ThreeDart.Entity cubeEntity = new ThreeDart.Entity(shape: Shapes.cube());

--- a/web/tests/test034/test.dart
+++ b/web/tests/test034/test.dart
@@ -14,13 +14,14 @@ import '../../common/common.dart' as common;
 void main() {
   new common.ShellPage("Test 034")
     ..addLargeCanvas("testCanvas")
-    ..addPar(["Test of resizing the render target."]);
+    ..addPar(["Test of resizing the render target. ",
+      "Resizing the canvas works better in Chrome."]);
 
   Element canvas = document.getElementById("testCanvas");
   canvas.style
     ..width = "100%"
     ..height = "100%"
-    ..margin = "-2px";
+    ..margin = "-4px";
   Element div = new DivElement();
   div.style
     ..border = "2px solid"

--- a/web/tests/test036/test.dart
+++ b/web/tests/test036/test.dart
@@ -24,7 +24,7 @@ void main() {
     ..add(new Movers.Constant.translate(0.0, 0.0, 5.0));
   Views.Perspective userCamera = new Views.Perspective(mover: secondMover);
 
-  Views.BackTarget target = new Views.BackTarget(800, 600)
+  Views.BackTarget back = new Views.BackTarget(800, 600, autoResize: true)
     ..color = new Math.Color4.transparent();
 
   ThreeDart.Entity obj = new ThreeDart.Entity()
@@ -42,7 +42,7 @@ void main() {
   Scenes.EntityPass pass = new Scenes.EntityPass()
     ..camera = userCamera
     ..technique = tech
-    ..target = target
+    ..target = back
     ..children.add(obj);
 
   Techniques.TextureLayout layout = new Techniques.TextureLayout(
@@ -54,16 +54,17 @@ void main() {
     for (int j = 0; j < count; ++j) {
       double yOffset = j.toDouble()*scale;
       layout.entries.add(new Techniques.TextureLayoutEntry(
-        texture: target.colorTexture,
+        texture: back.colorTexture,
         destination: new Math.Region2(xOffset, yOffset, scale, scale)));
     }
   }
   layout.entries.add(new Techniques.TextureLayoutEntry()
-    ..texture = target.colorTexture);
+    ..texture = back.colorTexture);
 
+  Views.FrontTarget front = new Views.FrontTarget(color: new Math.Color4.black());
   Scenes.CoverPass layoutCover = new Scenes.CoverPass()
     ..technique = layout
-    ..target = new Views.FrontTarget(color: new Math.Color4.black());
+    ..target = front;
 
   td.scene = new Scenes.Compound(passes: [pass, layoutCover]);
 


### PR DESCRIPTION
# Fix Back Buffer Target Sizes

## Feature, Bug Fix, or Improvement
<!-- A summary of the feature, steps to reproduce the bug,
or a description of the improvement -->

Back buffer targets get weird when resizing canvas.

## Implementation
<!-- A list of all the changes made. Any little fixes which were also found but
not specifically related to the issue. Any unit-tests or examples added -->

Added an auto-resize flag to back buffer targets

## Review and Testing
<!-- The list describing the steps to demonstrate the fix. Any additional notes to the
reviewers for things to look for while reviewing and any needed setup procedures -->

Check the unit-tests which use back buffers