### PR TITLE
Fix README and update webdev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .buildlog
 .DS_Store
 .dart_tool/
+.idea
 .pub/
 .vscode/
 build/

--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@
 
 ## Running
 
-- Run `webdev serve` from ThreeDart root directory.
+- Run `pub run webdev serve` from ThreeDart root directory.
+    - Note: You can also install webdev globally with `pub global activate webdev`
+     and run with `webdev serve` from the ThreeDart root directory.
 - Open `http://localhost:8080/` in a browser.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,3 +8,6 @@ dependencies:
   build_web_compilers: ^0.4.0
   OpenSimplexNoiseDart:
     git: git://github.com/Grant-Nelson/OpenSimplexNoiseDart.git
+
+dev_dependencies:
+  webdev: ^1.0.0


### PR DESCRIPTION

## Feature, Bug Fix, or Improvement
<!-- A summary of the feature, steps to reproduce the bug,
or a description of the improvement -->
- The README does not describe how to run `webdev`. 
- There is currently no way to run this project if you don't want to globally activate `webdev`.

## Implementation
<!-- A list of all the changes made. Any little fixes which were also found but
not specifically related to the issue. Any unit-tests or examples added -->
- Update the README describing how to install webdev.
- Add `webdev` as a dev dependency so you don't have to globally install it.
- Add `.idea` to `.gitignore` for Jetbrains products

## Review and Testing
<!-- The list describing the steps to demonstrate the fix. Any additional notes to the
reviewers for things to look for while reviewing and any needed setup procedures -->
Run `pub get` and `pub run webdev serve` and verify you can nav to `localhost:8080`