### PR TITLE
Init world from seed query param.

### DIFF
--- a/web/examples/craft/main.dart
+++ b/web/examples/craft/main.dart
@@ -18,6 +18,7 @@ import 'package:OpenSimplexNoiseDart/OpenSimplexNoise.dart' as simplex;
 import 'dart:math' as math;
 import 'dart:typed_data' as data;
 import 'dart:async';
+import 'dart:html' as html;
 
 import '../../common/common.dart' as common;
 
@@ -67,11 +68,15 @@ void main() {
 }
 
 void startCraft() {
+  int seed = _getSeed();
+  if (seed == null) {
+    seed = _navigateToSeededUrl();
+  }
+
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("targetCanvas");
   Materials mats = new Materials(td);
-  World world = new World(mats);
+  World world = new World(mats, seed);
   Player player = new Player(td, world);
-
   Scenes.EntityPass scene = new Scenes.EntityPass()
     ..onPreUpdate.add(world.update)
     ..camera.mover = player.camera;
@@ -92,4 +97,23 @@ void startCraft() {
     String fps = td.fps.toStringAsFixed(2);
     print("$fps fps, "+world.debugString());
   });
+}
+
+/// Returns the seed provided by the URL's query parameters, or null if no seed is found.
+int _getSeed() {
+  String seedQueryParam = Uri.base.queryParameters["seed"];
+  if (seedQueryParam == null) {
+    return null;
+  }
+
+  return int.tryParse(seedQueryParam);
+}
+
+/// Navigates the browser to a Url with a seed parameter and returns the seed.
+int _navigateToSeededUrl() {
+  // Note: 2^32 is the maximum value allowed.
+  int seed = new math.Random().nextInt(math.pow(2, 32));
+  Uri newUri = Uri.base.replace(queryParameters: {"seed": "$seed"});
+  html.window.history.pushState(null, null, newUri.toString());
+  return seed;
 }

--- a/web/examples/craft/main.dart
+++ b/web/examples/craft/main.dart
@@ -77,6 +77,7 @@ void startCraft() {
   Materials mats = new Materials(td);
   World world = new World(mats, seed);
   Player player = new Player(td, world);
+
   Scenes.EntityPass scene = new Scenes.EntityPass()
     ..onPreUpdate.add(world.update)
     ..camera.mover = player.camera;

--- a/web/examples/craft/world.dart
+++ b/web/examples/craft/world.dart
@@ -10,9 +10,9 @@ class World {
   Player _player;
   Chunk _lastChunk;
 
-  /// Creates a new world with the given meterials.
-  World(this._mats) {
-    this._gen = new Generator();
+  /// Creates a new world with the given materials.
+  World(this._mats, [int seed = 0]) {
+    this._gen = new Generator(seed);
     this._graveyard = new List<Chunk>();
     this._chunks = new List<Chunk>();
     this._entities = new List<ThreeDart.Entity>();


### PR DESCRIPTION
# [Randomize](https://github.com/Grant-Nelson/ThreeDart/issues/28)

## Feature, Bug Fix, or Improvement
<!-- A summary of the feature, steps to reproduce the bug,
or a description of the improvement -->
The ability to generate the world from a seed using a URL parameter.

## Implementation
<!-- A list of all the changes made. Any little fixes which were also found but
not specifically related to the issue. Any unit-tests or examples added -->
Adding a `?seed` URL parameter which will generate the world from the given seed. If no valid seed is provided, a new seed is generated and the URL is navigated to that seed.

## Review and Testing
<!-- The list describing the steps to demonstrate the fix. Any additional notes to the
reviewers for things to look for while reviewing and any needed setup procedures -->

- Navigate to `http://localhost:8080/examples/craft/` and verify that a seed is added to the URL.
- Navigate to `http://localhost:8080/examples/craft/?seed=1234` (or the seed of your choosing and verify the world is generated)
- Refreshing the browser with a seed param should generate the world in the same way
- Adding a non-integer seed as a URL param will generate an integer seed and navigate the browser.
