### PR TITLE
Added shader printouts and event once

### DIFF
--- a/lib/src/Shaders/Shader.dart
+++ b/lib/src/Shaders/Shader.dart
@@ -5,6 +5,9 @@ abstract class Shader extends Core.Bindable {
   WebGL.RenderingContext _gl;
   String _name;
 
+  String _vertexSourceCode;
+  String _fragmentSourceCode;
+
   WebGL.Shader _vertexShader;
   WebGL.Shader _fragmentShader;
   WebGL.Program _program;
@@ -14,6 +17,8 @@ abstract class Shader extends Core.Bindable {
 
   /// Creates a shader with the given rendering context and name.
   Shader(this._gl, this._name) {
+    this._vertexSourceCode = null;
+    this._fragmentSourceCode = null;
     this._vertexShader = null;
     this._fragmentShader = null;
     this._program = null;
@@ -22,9 +27,11 @@ abstract class Shader extends Core.Bindable {
   }
 
   /// initializes and compiles the shader with the given vertex and fragment sources.
-  void initialize(String vertexSource, String fragmentSource) {
-    this._vertexShader = this._createShader(vertexSource, WebGL.WebGL.VERTEX_SHADER);
-    this._fragmentShader = this._createShader(fragmentSource, WebGL.WebGL.FRAGMENT_SHADER);
+  void initialize(String vertexSourceCode, String fragmentSourceCode) {
+    this._vertexSourceCode = vertexSourceCode;
+    this._fragmentSourceCode = fragmentSourceCode;
+    this._vertexShader = this._createShader(this._vertexSourceCode, WebGL.WebGL.VERTEX_SHADER);
+    this._fragmentShader = this._createShader(this._fragmentSourceCode, WebGL.WebGL.FRAGMENT_SHADER);
     this._createProgram();
     this._setupAttributes();
     this._setupUniform();
@@ -32,6 +39,12 @@ abstract class Shader extends Core.Bindable {
 
   /// The name of the shader.
   String get name => this._name;
+  
+  /// Gets the vertex source code used for this shader.
+  String get vertexSourceCode => this._vertexSourceCode;
+
+  /// Gets the fragment source code used for this shader.
+  String get fragmentSourceCode => this._fragmentSourceCode;
 
   /// The list of attributes for this shader.
   AttributeContainer get attributes => this._attrs;

--- a/lib/src/Techniques/Depth.dart
+++ b/lib/src/Techniques/Depth.dart
@@ -82,6 +82,12 @@ class Depth extends Technique {
     }
   }
 
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
+
   /// Updates this technique for the given state.
   void update(Core.RenderState state) {
     // Do Nothing

--- a/lib/src/Techniques/Distort.dart
+++ b/lib/src/Techniques/Distort.dart
@@ -85,6 +85,12 @@ class Distort extends Technique {
     }
   }
 
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
+
   /// Updates this technique for the given state.
   void update(Core.RenderState state) {
     // Do Nothing

--- a/lib/src/Techniques/GaussianBlur.dart
+++ b/lib/src/Techniques/GaussianBlur.dart
@@ -114,6 +114,12 @@ class GaussianBlur extends Technique {
     }
   }
 
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
+
   /// Updates this technique for the given state.
   void update(Core.RenderState state) {
     // Do Nothing

--- a/lib/src/Techniques/MaterialLight.dart
+++ b/lib/src/Techniques/MaterialLight.dart
@@ -152,13 +152,17 @@ class MaterialLight extends Technique {
 
   /// The alpha value or scalar on the alpha texture for the material.
   MaterialLightAlphaComponent get alpha => this._alpha;
+  
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
 
   /// Calculates a limit for the lights and other arrays for the shader from
   /// the current number of lights and lengths. This helps reduce and reuse
   /// shaders with similar number of attributes.
-  int _lengthLimit(int count) {
-    return ((count + 3) ~/ 4) * 4;
-  }
+  int _lengthLimit(int count) => ((count + 3) ~/ 4) * 4;
 
   /// Creates the configuration for this shader.
   Shaders.MaterialLightConfig _config() {
@@ -199,6 +203,7 @@ class MaterialLight extends Technique {
       this._shader = new Shaders.MaterialLight.cached(this._config(), state);
       obj.clearCache();
     }
+
     Shaders.MaterialLightConfig cfg = this._shader.configuration;
     Data.VertexType vertexType = cfg.vertexType;
     if (obj.cache is! Data.BufferStore) obj.clearCache();

--- a/lib/src/Techniques/Normal.dart
+++ b/lib/src/Techniques/Normal.dart
@@ -72,6 +72,12 @@ class Normal extends Technique {
     }
   }
 
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
+
   /// Removes any normal distortion from the material.
   void clearBump() {
     if (this._bumpyType != Shaders.ColorSourceType.None) {

--- a/lib/src/Techniques/Skybox.dart
+++ b/lib/src/Techniques/Skybox.dart
@@ -62,6 +62,12 @@ class Skybox extends Technique {
     }
   }
 
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
+
   /// Updates this technique for the given state.
   void update(Core.RenderState state) {
     // Do Nothing

--- a/web/common/glslParser.dart
+++ b/web/common/glslParser.dart
@@ -47,13 +47,15 @@ class GLSLParser extends CodeParser {
     tok.join("Float", "Float")
       ..addRange("0", "9");
     tok.join("Start", "Sym")
-      ..addSet("<>{}()\\-+*%!&|=.,?:;");
+      ..addSet("<>{}()[]\\-+*%!&|=.,?:;");
     tok.join("Sym", "Sym")
-      ..addSet("<>{}()\\-+*%!&|=.,?:;");
+      ..addSet("<>{}()[]\\-+*%!&|=.,?:;");
     tok.join("Start", "Slash")
       ..addSet("/");
     tok.join("Slash", "Comment")
       ..addSet("/");
+    tok.join("Slash", "Sym")
+      ..addAll();
     tok.join("Comment", "EndComment")
       ..addSet("\n");
     tok.join("Comment", "Comment")

--- a/web/tests/test001/test.dart
+++ b/web/tests/test001/test.dart
@@ -8,7 +8,7 @@ import 'package:ThreeDart/Scenes.dart' as Scenes;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 001")
+  common.ShellPage page = new common.ShellPage("Test 001")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Depth shader, a basic fog shader with a single auto-rotating shape."])
     ..addPar(["«[Back to Tests|../]"]);
@@ -17,13 +17,19 @@ void main() {
     ..shape = Shapes.toroid()
     ..mover = new Movers.Rotater();
 
+  Techniques.Depth tech = new Techniques.Depth(fogStart: 3.0, fogStop: 6.0);
   Scenes.EntityPass pass = new Scenes.EntityPass()
     ..children.add(obj)
-    ..technique = new Techniques.Depth(fogStart: 3.0, fogStop: 6.0)
+    ..technique = tech
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
 
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("testCanvas")
     ..scene = pass;
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test003/test.dart
+++ b/web/tests/test003/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 003")
+  common.ShellPage page = new common.ShellPage("Test 003")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Light Shader with a solid color directional lighting."])
     ..addPar(["«[Back to Tests|../]"]);
@@ -36,5 +36,10 @@ void main() {
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("testCanvas")
     ..scene = pass;
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test004/test.dart
+++ b/web/tests/test004/test.dart
@@ -8,7 +8,7 @@ import 'package:ThreeDart/Scenes.dart' as Scenes;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 004")
+  common.ShellPage page = new common.ShellPage("Test 004")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of repeat use of a single mover and shape. There are 9 rings ",
       "moving at the same speed, however the second one is attached to ",
@@ -36,13 +36,19 @@ void main() {
   ThreeDart.Entity obj7 = new ThreeDart.Entity(shape: shape, mover: mover)..children.add(obj6);
   ThreeDart.Entity obj8 = new ThreeDart.Entity(shape: shape, mover: mover)..children.add(obj7);
 
+  Techniques.Depth tech = new Techniques.Depth(fogStart: 3.0, fogStop: 6.0);
   Scenes.EntityPass pass = new Scenes.EntityPass()
-    ..technique = new Techniques.Depth(fogStart: 3.0, fogStop: 6.0)
+    ..technique = tech
     ..children.add(obj8)
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
 
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("testCanvas")
     ..scene = pass;
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test005/test.dart
+++ b/web/tests/test005/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Textures.dart' as Textures;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 005")
+  common.ShellPage page = new common.ShellPage("Test 005")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with 2D textures and directional ",
       "lighting. This test has texturing for emission, ambient, diffuse, and ",
@@ -44,5 +44,10 @@ void main() {
     ..children.add(obj)
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test006/test.dart
+++ b/web/tests/test006/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 006")
+  common.ShellPage page = new common.ShellPage("Test 006")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with a bumpy 2D texture and ",
       "a directional light. Select different bump maps for the test. ",
@@ -67,5 +67,10 @@ void main() {
     ..add("../resources/ScrewBumpMap.png")
     ..add("../resources/CtrlPnlBumpMap.png");
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test007/test.dart
+++ b/web/tests/test007/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Textures.dart' as Textures;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 007")
+  common.ShellPage page = new common.ShellPage("Test 007")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with bumpy 2D textures and ",
       "a directional light. The lighting and bump is being applied to ",
@@ -46,5 +46,10 @@ void main() {
     ..children.add(obj)
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test008/BumpyTechnique.dart
+++ b/web/tests/test008/BumpyTechnique.dart
@@ -48,6 +48,12 @@ class BumpyTechnique extends Techniques.Technique {
     }
   }
 
+  /// Gets the vertex source code used for the shader used by this techinique.
+  String get vertexSourceCode => this._shader?.vertexSourceCode;
+
+  /// Gets the fragment source code used for the shader used by this techinique.
+  String get fragmentSourceCode => this._shader?.fragmentSourceCode;
+
   /// Updates this technique for the given state.
   void update(ThreeDart.RenderState state) {
     // Do Nothing

--- a/web/tests/test008/test.dart
+++ b/web/tests/test008/test.dart
@@ -18,7 +18,7 @@ part 'BumpyShader.dart';
 part 'BumpyTechnique.dart';
 
 void main() {
-  new common.ShellPage("Test 008")
+  common.ShellPage page = new common.ShellPage("Test 008")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A custom shader for testing and fixing the normal distortion ",
       "equation used for bump maps. This displays the normal vectors ",
@@ -80,5 +80,10 @@ void main() {
     ..add("0.9", () { tech.offsetScalar = 0.9; })
     ..add("1.0", () { tech.offsetScalar = 1.0; });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test009/test.dart
+++ b/web/tests/test009/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 009")
+  common.ShellPage page = new common.ShellPage("Test 009")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Another test of the Material Lighting shader with solid color and ",
       "a directional lighting. The light and object don't move but the camera can be ",
@@ -43,5 +43,10 @@ void main() {
     ..children.add(obj)
     ..camera.mover = camMover;
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test010/test.dart
+++ b/web/tests/test010/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 010")
+  common.ShellPage page = new common.ShellPage("Test 010")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with solid color and ",
       "a directional light= with a cube texture bump map."])
@@ -40,5 +40,10 @@ void main() {
     ..children.add(obj)
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test011/test.dart
+++ b/web/tests/test011/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 011")
+  common.ShellPage page = new common.ShellPage("Test 011")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with cube textures and ",
       "a directional light. The cube textures are for ambient, diffuse, ",
@@ -56,5 +56,10 @@ void main() {
     ..add("Toroid",       () { obj.shape = Shapes.toroid(); })
     ..add("Knot",         () { obj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test012/test.dart
+++ b/web/tests/test012/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 012")
+  common.ShellPage page = new common.ShellPage("Test 012")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with cube textures and ",
       "a directional light with a cube texture bump map."])
@@ -45,5 +45,10 @@ void main() {
     ..children.add(obj)
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test013/test.dart
+++ b/web/tests/test013/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 013")
+  common.ShellPage page = new common.ShellPage("Test 013")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of sky box and cover pass."])
     ..addPar(["«[Back to Tests|../]"]);
@@ -53,5 +53,11 @@ void main() {
 
   td.scene = new Scenes.Compound(passes: [skybox, pass]);
 
+  td.postrender.once((_){
+    Techniques.Skybox skyTech = skybox.technique as Techniques.Skybox;
+    page
+      ..addCode("Vertex Shader for Skybox", "glsl", 0, skyTech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader for Skybox", "glsl", 0, skyTech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test014/test.dart
+++ b/web/tests/test014/test.dart
@@ -14,7 +14,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 014")
+  common.ShellPage page = new common.ShellPage("Test 014")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of Material Lighting shader with different reflections and refractions. "+
       "No alpha is being used. The background cube maps is being painted onto the object."])
@@ -165,5 +165,10 @@ void main() {
     ..add("Toroid",        () { obj.shape = Shapes.toroid(); }, true)
     ..add("Knot",          () { obj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test015/test.dart
+++ b/web/tests/test015/test.dart
@@ -12,7 +12,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 015")
+  common.ShellPage page = new common.ShellPage("Test 015")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of Material Lighting shader with bump mapping, reflections, refractions."])
     ..addControlBoxes(["bumpMaps", "controls"])
@@ -143,5 +143,10 @@ void main() {
     ..add("../resources/ScrewBumpMap.png")
     ..add("../resources/CtrlPnlBumpMap.png");
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test016/test.dart
+++ b/web/tests/test016/test.dart
@@ -12,7 +12,7 @@ import 'package:ThreeDart/Views.dart' as Views;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 016")
+  common.ShellPage page = new common.ShellPage("Test 016")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with cube texturing, ",
       "bump mapping, and a color directional light."])
@@ -65,5 +65,10 @@ void main() {
 
   td.scene = new Scenes.Compound(passes: [skybox, pass]);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test017/test.dart
+++ b/web/tests/test017/test.dart
@@ -12,7 +12,7 @@ import 'package:ThreeDart/Views.dart' as Views;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 017")
+  common.ShellPage page = new common.ShellPage("Test 017")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with solid color directional "+
       "light, cube mapped textures, and a reflection map. The specular map is "+
@@ -77,5 +77,10 @@ void main() {
     ..add("Toroid",       () { obj.shape = Shapes.toroid(); })
     ..add("Knot",         () { obj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test018/test.dart
+++ b/web/tests/test018/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 018")
+  common.ShellPage page = new common.ShellPage("Test 018")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader where a diffuse textue and ",
       "inverse diffuse texture are used. Grass is only shown in the dark. ",
@@ -53,5 +53,10 @@ void main() {
     ..add("Toroid",       () { obj.shape = Shapes.toroid(); })
     ..add("Knot",         () { obj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test019/test.dart
+++ b/web/tests/test019/test.dart
@@ -12,7 +12,7 @@ import 'package:ThreeDart/Views.dart' as Views;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 019")
+  common.ShellPage page = new common.ShellPage("Test 019")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Material Lighting shader with an alpha texture. ",
       "There are no mapped reflections, this is actually transparent."])
@@ -59,5 +59,10 @@ void main() {
 
   td.scene = new Scenes.Compound(passes: [skybox, pass]);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test020/test.dart
+++ b/web/tests/test020/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 020")
+  common.ShellPage page = new common.ShellPage("Test 020")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Matrial Lighting shader with multiple moving directional lights."])
     ..addControlBoxes(["shapes"])
@@ -67,5 +67,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test021/test.dart
+++ b/web/tests/test021/test.dart
@@ -37,7 +37,7 @@ void addLightBall(Techniques.MaterialLight tech, Scenes.EntityPass pass,
 }
 
 void main() {
-  new common.ShellPage("Test 021")
+  common.ShellPage page = new common.ShellPage("Test 021")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Material Lighting shader with multiple moving point lights. ",
       "Emissive spheres are added at the lights sources."])
@@ -84,5 +84,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test022/test.dart
+++ b/web/tests/test022/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 022")
+  common.ShellPage page = new common.ShellPage("Test 022")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Material Lighting shader with a textured point light."])
     ..addControlBoxes(["shapes"])
@@ -75,5 +75,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test023/test.dart
+++ b/web/tests/test023/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 023")
+  common.ShellPage page = new common.ShellPage("Test 023")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Material Lighting shader with a textured directional ",
       "light. Use Ctrl plus the mouse to move the light."])
@@ -61,5 +61,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test024/test.dart
+++ b/web/tests/test024/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 024")
+  common.ShellPage page = new common.ShellPage("Test 024")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Material Lighting shader with a simple spot light. ",
       "Use Ctrl plus the mouse to move the light."])
@@ -75,5 +75,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test025/test.dart
+++ b/web/tests/test025/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 025")
+  common.ShellPage page = new common.ShellPage("Test 025")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of the Material Lighting shader with a textured spot light. ",
       "Use Ctrl plus the mouse to move the light."])
@@ -75,5 +75,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test026/test.dart
+++ b/web/tests/test026/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 026")
+  common.ShellPage page = new common.ShellPage("Test 026")
     ..addLargeCanvas("testCanvas")
     ..addPar([
       "Test of the Material Lighting shader with a textured directional light. ",
@@ -74,5 +74,10 @@ void main() {
     ..add("Toroid",   () { centerObj.shape = Shapes.toroid(); }, true)
     ..add("Knot",     () { centerObj.shape = Shapes.knot(); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test027/test.dart
+++ b/web/tests/test027/test.dart
@@ -1,5 +1,7 @@
 library ThreeDart.test.test027;
 
+import 'dart:math';
+
 import 'package:ThreeDart/ThreeDart.dart' as ThreeDart;
 import 'package:ThreeDart/Shapes.dart' as Shapes;
 import 'package:ThreeDart/Movers.dart' as Movers;
@@ -11,10 +13,11 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 027")
+  common.ShellPage page = new common.ShellPage("Test 027")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of a back buffer target for rendering to a texture. ",
       "That back buffer texture is applied to a box."])
+    ..addControlBoxes(["shapes"])
     ..addPar(["«[Back to Tests|../]"]);
 
   ThreeDart.ThreeDart td = new ThreeDart.ThreeDart.fromId("testCanvas");
@@ -70,5 +73,29 @@ void main() {
 
   td.scene = new Scenes.Compound(passes: [skybox, firstPass, secondPass]);
 
+  new common.RadioGroup("shapes")
+    ..add("Cube",          () { secondObj.shape = Shapes.cube(); }, true)
+    ..add("Cuboid",        () { secondObj.shape = Shapes.cuboid(widthDiv: 15, heightDiv: 15,
+                                vertexHndl: (Shapes.Vertex ver, double u, double v) {
+                                  double height = cos(v*4.0*Math.PI+Math.PI)*0.1 + cos(u*4.0*Math.PI+Math.PI)*0.1;
+                                  Math.Vector3 vec = new Math.Vector3.fromPoint3(ver.location).normal();
+                                  ver.location += new Math.Point3.fromVector3(vec*height);
+                                });
+                              })
+    ..add("Cylinder",      () { secondObj.shape = Shapes.cylinder(sides: 30); })
+    ..add("Cone",          () { secondObj.shape = Shapes.cylinder(topRadius: 0.0, sides: 30, capTop: false); })
+    ..add("Cylindrical",   () { secondObj.shape = Shapes.cylindrical(sides: 50, div: 25,
+                                radiusHndl: (double u, double v) => cos(v*4.0*Math.PI + Math.PI)*0.2 + cos(u*6.0*Math.PI)*0.3 + 0.8); })
+    ..add("Sphere",        () { secondObj.shape = Shapes.sphere(widthDiv: 6, heightDiv: 6); })
+    ..add("Spherical",     () { secondObj.shape = Shapes.sphere(widthDiv: 10, heightDiv: 10,
+                                heightHndl: (double u, double v) => cos(sqrt((u-0.5)*(u-0.5) + (v-0.5)*(v-0.5))*Math.PI)*0.3); })
+    ..add("Toroid",        () { secondObj.shape = Shapes.toroid(); })
+    ..add("Knot",          () { secondObj.shape = Shapes.knot(); });
+
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, secondTech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, secondTech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test028/test.dart
+++ b/web/tests/test028/test.dart
@@ -12,7 +12,7 @@ import 'package:ThreeDart/Scenes.dart' as Scenes;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 028")
+  common.ShellPage page = new common.ShellPage("Test 028")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of a Gaussian blur cover pass. ",
       "Notice the depth of field causing things further away to be blurry."])
@@ -80,13 +80,14 @@ void main() {
     ..technique = new Techniques.Depth(fogStart: 3.5, fogStop: 5.5)
     ..children.add(group);
 
-  Scenes.CoverPass blurPass = new Scenes.CoverPass()
-    ..technique = new Techniques.GaussianBlur(
+  Techniques.GaussianBlur blurTech = new Techniques.GaussianBlur(
       colorTxt: colorTarget.colorTexture,
       depthTxt: depthTarget.colorTexture,
       highOffset: 0.0,
       lowOffset: 8.0,
       depthLimit: 0.001);
+  Scenes.CoverPass blurPass = new Scenes.CoverPass()
+    ..technique = blurTech;
 
   Techniques.TextureLayout layoutTech = new Techniques.TextureLayout()
     ..entries.add(new Techniques.TextureLayoutEntry(
@@ -101,5 +102,10 @@ void main() {
 
   td.scene = new Scenes.Compound(passes: [skybox, colorPass, depthPass, blurPass, layout]);
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader for blur", "glsl", 0, blurTech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader for blur", "glsl", 0, blurTech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test029/test.dart
+++ b/web/tests/test029/test.dart
@@ -11,7 +11,7 @@ import 'package:ThreeDart/Lights.dart' as Lights;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 029")
+  common.ShellPage page = new common.ShellPage("Test 029")
     ..addLargeCanvas("testCanvas")
     ..addPar(["Test of bump distort pass. It renders the scene to a back buffer then ",
       "paints that back buffer texture to the front buffer with a distortion."])
@@ -72,5 +72,10 @@ void main() {
     ..add("../resources/ScrewBumpMap.png")
     ..add("../resources/CtrlPnlBumpMap.png");
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader for distort", "glsl", 0, distortTech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader for distort", "glsl", 0, distortTech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test030/test.dart
+++ b/web/tests/test030/test.dart
@@ -10,7 +10,7 @@ import 'package:ThreeDart/Views.dart' as Views;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 030")
+  common.ShellPage page = new common.ShellPage("Test 030")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of the Normal shader for dynamically rendering normal maps."])
     ..addPar(["«[Back to Tests|../]"]);
@@ -37,5 +37,10 @@ void main() {
     ..camera.mover = new Movers.Constant.translate(0.0, 0.0, 5.0);
   td.scene = pass;
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }

--- a/web/tests/test037/test.dart
+++ b/web/tests/test037/test.dart
@@ -12,7 +12,7 @@ import 'package:ThreeDart/Scenes.dart' as Scenes;
 import '../../common/common.dart' as common;
 
 void main() {
-  new common.ShellPage("Test 037")
+  common.ShellPage page = new common.ShellPage("Test 037")
     ..addLargeCanvas("testCanvas")
     ..addPar(["A test of applying a height map to an image. ",
       "Some shapes will take a bit to calculate depending on quality of mapping."])
@@ -99,5 +99,10 @@ void main() {
     ..add("0.8", () { setScalar(0.8); })
     ..add("1.0", () { setScalar(1.0); });
 
+  td.postrender.once((_){
+    page
+      ..addCode("Vertex Shader", "glsl", 0, tech.vertexSourceCode.split("\n"))
+      ..addCode("Fragment Shader", "glsl", 0, tech.fragmentSourceCode.split("\n"));
+  });
   common.showFPS(td);
 }


### PR DESCRIPTION
# Printing shaders

## Feature, Bug Fix, or Improvement

Print shaders on most of the graphical unit-tests

## Implementation

- Added string methods to get the shaders
- Added a once handler to the event which fires only once
- Added printouts to most graphical unit-tests

## Review and Testing

- [ ] Check the shaders are being printed and look good with no console errors
