### PR TITLE
Fixed mouse movements in Hypercube

### DIFF
--- a/web/examples/hypersphere/example2D.dart
+++ b/web/examples/hypersphere/example2D.dart
@@ -61,10 +61,13 @@ void startup2D(String targetName) {
     ..children.add(squareLine);
 
   // Add the left side slider control.
-  double wOffset =0.0;
+  double wOffset = 0.5;
+  bool startInside = false;
+  td.userInput.mouse.down.add((_){ startInside = true; });
+  td.userInput.mouse.up.add((_){ startInside = false; });
   td.userInput.mouse.move.add((Events.EventArgs e) {
     Input.MouseEventArgs ms = e as Input.MouseEventArgs;
-    if (!ms.button.has(Input.Button.left)) return;
+    if (!startInside) return;
 
     wOffset += ms.adjustedDelta.dy;
     wOffset = Math.clampVal(wOffset, -0.1, 1.1);

--- a/web/examples/hypersphere/example3D.dart
+++ b/web/examples/hypersphere/example3D.dart
@@ -67,10 +67,13 @@ void startup3D(String targetName) {
     ..children.add(square);
 
   // Add the left side slider control.
-  double wOffset =0.0;
+  double wOffset = 0.5;
+  bool startInside = false;
+  td.userInput.mouse.down.add((_){ startInside = true; });
+  td.userInput.mouse.up.add((_){ startInside = false; });
   td.userInput.mouse.move.add((Events.EventArgs e) {
     Input.MouseEventArgs ms = e as Input.MouseEventArgs;
-    if (!ms.button.has(Input.Button.left)) return;
+    if (!startInside) return;
 
     wOffset += ms.adjustedDelta.dy;
     wOffset = Math.clampVal(wOffset, -0.1, 1.1);

--- a/web/examples/hypersphere/example4D.dart
+++ b/web/examples/hypersphere/example4D.dart
@@ -100,10 +100,13 @@ void startup4D(String targetName) {
     ..children.add(cube);
 
   // Add the left side slider control.
-  double wOffset =0.0;
+  double wOffset = 0.5;
+  bool startInside = false;
+  td.userInput.mouse.down.add((_){ startInside = true; });
+  td.userInput.mouse.up.add((_){ startInside = false; });
   td.userInput.mouse.move.add((Events.EventArgs e) {
     Input.MouseEventArgs ms = e as Input.MouseEventArgs;
-    if (!ms.button.has(Input.Button.left)) return;
+    if (!startInside) return;
     // If on the right size, don't move the slider.
     if (ms.adjustedPoint.x > 0.0) return;
 


### PR DESCRIPTION
# Fix mouse movements in Hypercube

## Feature, Bug Fix, or Improvement

When moving one slice in one of the canvases in the Hypercube example. the other canvases also move.

## Implementation

Made them check the mouse down and mouse up to keep it associated with the specific canvas.

## Review and Testing

Check out the Hypercube example and try mouse movements in it to see if they mess with other canvases.
