### PR TITLE
Update plant placement

### DIFF
--- a/web/examples/craft/blockInfo.dart
+++ b/web/examples/craft/blockInfo.dart
@@ -26,6 +26,14 @@ class BlockInfo {
   /// Creates a new block info.
   BlockInfo(this.x, this.y, this.z, this.chunkX, this.chunkZ, this.chunk);
 
+  /// Creates a new block info for the one above the given non-null info.
+  factory BlockInfo.above(BlockInfo info) =>
+    new BlockInfo(info.x, info.y+1, info.z, info.chunkX, info.chunkZ, info.chunk);
+
+  /// Creates a new block info for the one below the given non-null info.
+  factory BlockInfo.below(BlockInfo info) =>
+    new BlockInfo(info.x, info.y-1, info.z, info.chunkX, info.chunkZ, info.chunk);
+
   /// Gets the block info string for debugging.
   @override
   String toString() => "$chunk.block($x, $y, $z, ($chunkX, $chunkZ), ${BlockType.string(value)})";

--- a/web/examples/craft/blockType.dart
+++ b/web/examples/craft/blockType.dart
@@ -156,12 +156,17 @@ class BlockType {
 
   /// hard determines if the given block type can not be walked through.
   static bool hard(int value) {
-    return solid(value);
+    return (value >= Boundary) && (value <= WoodEW);
   }
 
   /// solid determines if the given block type can not be seen through.
   static bool solid(int value) {
     return (value >= Boundary) && (value <= WoodEW);
+  }
+
+  /// plant determines if the given block type is a plant.
+  static bool plant(int value) {
+    return (value >= Grass) && (value <= Mushroom);
   }
 
   /// open determines if the given block type can be seen through.


### PR DESCRIPTION
# [Issue #68](https://github.com/Grant-Nelson/ThreeDart/issues/68)

## Feature, Bug Fix, or Improvement

Remove grass/plants when block below it is removed

## Implementation

- Remove grass/plants when block below it is removed
- Made it so a plant can't be placed on a non-solid
- Made it so a block can't be put on a plant

## Review and Testing

Try putting a block and plant in different locations and check that it matches the defined implementation.
