### PR TITLE
Bug fixes001

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2019, SnowGremlin LLC.
+Copyright (c) 2015-2020, SnowGremlin LLC.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/src/Core/Core.dart
+++ b/lib/src/Core/Core.dart
@@ -20,6 +20,7 @@ import '../Textures/Textures.dart' as Textures;
 part 'Bindable.dart';
 part 'Entity.dart';
 part 'EntityEventArgs.dart';
+part 'Environment.dart';
 part 'RenderState.dart';
 part 'StateEventArgs.dart';
 part 'ThreeDart.dart';

--- a/lib/src/Core/Environment.dart
+++ b/lib/src/Core/Environment.dart
@@ -1,0 +1,109 @@
+part of ThreeDart.Core;
+
+/// This is the type of the browser this code is running on.
+enum Browser {
+
+  /// This indicates the browser type is Google's Chrome.
+  chrome,
+
+  /// This indicates the browser is Mozilla's Firefox.
+  firefox,
+
+  /// This indicates the browser is Microsoft's Edge or IE.
+  edge,
+  
+  /// This indicates the browser is some other browser. 
+  other
+}
+
+/// This is the type of the operating system this code is running on.
+enum OperatingSystem {
+
+  /// This indicates the operating system is Windows.
+  windows,
+
+  /// This indicates the operating system is MacOS.
+  mac,
+
+  /// This indicates the operating system is Linux.
+  linux,
+
+  /// This indicates the operating system is some other OS.
+  other
+}
+
+/// A static class for getting information about the environment this code is running in.
+/// Try to limit usage of the Environment so that all features work the same in all
+/// scenarios. This is designed to be used to adjust for problems in the environment
+/// which makes the code function differently.
+class Environment {
+  static _EnvironmentData _singleton = null;
+  Environment._();
+  
+  /// Gets the lazy created singleton with the environment data.
+  static _EnvironmentData get _env {
+    _singleton ??= new _EnvironmentData();
+    return _singleton;
+  }
+
+  /// Gets the browser that this code is running on.
+  static Browser get browser => _env.browser;
+
+  /// Gets the operating system that this code is running on.
+  static OperatingSystem get os => _env.os;
+}
+
+/// This is storage for environment information.
+/// This is part of a singleton so it is only created once.
+class _EnvironmentData {
+  final Browser browser;
+  final OperatingSystem os;
+
+  /// Creates a new environment with the given data.
+  _EnvironmentData._(this.browser, this.os);
+
+  /// Determines the environment which this code is running in.
+  factory _EnvironmentData() {
+    Browser browser = _determineBrowser();
+    OperatingSystem os = _determineOS();
+    return new _EnvironmentData._(browser, os);
+  }
+  
+  /// Determines which kind of browser is being used.
+  static Browser _determineBrowser() {
+    final String vendor = html.window.navigator.vendor;
+    if (vendor.contains('Google'))
+      return Browser.chrome;
+    
+    final String userAgent = html.window.navigator.userAgent;
+    if (userAgent.contains('Firefox'))
+      return Browser.firefox;
+
+    final String appVersion = html.window.navigator.appVersion;
+    if (appVersion.contains('Trident') || appVersion.contains('Edge'))
+      return Browser.edge;
+
+    final String appName = html.window.navigator.appName;
+    if (appName.contains('Microsoft'))
+      return Browser.edge;
+
+    return Browser.other;
+  }
+
+  /// Determines which kind of operating system is being used.
+  /// This doesn't use `dart:io` so it can run on a browser.
+  static OperatingSystem _determineOS() {
+    final String appVersion = html.window.navigator.appVersion;
+
+    if (appVersion.contains('Win'))
+      return OperatingSystem.windows;
+
+    if (appVersion.contains('Mac'))
+      return OperatingSystem.mac;
+
+    if (appVersion.contains('Linux'))
+      return OperatingSystem.linux;
+
+    return OperatingSystem.other;
+  }
+}

--- a/lib/src/Input/Input.dart
+++ b/lib/src/Input/Input.dart
@@ -3,6 +3,7 @@ library ThreeDart.Input;
 import 'dart:html' as html;
 import 'dart:async' as async;
 
+import '../Core/Core.dart' as Core;
 import '../Collections/Collections.dart' as Collections;
 import '../Events/Events.dart' as Events;
 import '../Math/Math.dart' as Math;

--- a/lib/src/Input/UserInput.dart
+++ b/lib/src/Input/UserInput.dart
@@ -13,6 +13,7 @@ class UserInput {
   bool _pointerLocked;
   html.MouseEvent _msEventOnLock;
   List<async.StreamSubscription<Object>> _eventStreams;
+  double _wheelScalar;
 
   /// Creates a new user input for the given [_elem].
   UserInput(this._elem) {
@@ -25,7 +26,8 @@ class UserInput {
     this._pointerLocked = false;
     this._msEventOnLock = null;
     this._eventStreams = new List<async.StreamSubscription<Object>>();
-
+    this._wheelScalar = (Core.Environment.browser == Core.Browser.firefox)? 1.0/6.0: 1.0/180.0;
+  
     this._eventStreams.add(html.document.onContextMenu.listen(this._onContentMenu));
     this._eventStreams.add(this._elem.onFocus.listen(this._onFocus));
     this._eventStreams.add(this._elem.onBlur.listen(this._onBlur));
@@ -271,7 +273,7 @@ class UserInput {
   /// Handles the mouse wheel being moved over the canvas.
   void _onMouseWheel(html.WheelEvent msEvent) {
     this._setMouseModifiers(msEvent);
-    final Math.Vector2 wheel = new Math.Vector2(msEvent.deltaX, msEvent.deltaY)/180.0;
+    final Math.Vector2 wheel = new Math.Vector2(msEvent.deltaX, msEvent.deltaY)*this._wheelScalar;
 
     if (this._pointerLocked) {
       if (this._locked.performWheel(wheel))

--- a/lib/src/Math/Vector4.dart
+++ b/lib/src/Math/Vector4.dart
@@ -67,7 +67,7 @@ class Vector4 {
   static Vector4 _negWSingleton;
 
   /// Gets the default shadow adjustment.
-  /// The RBG higher quality depth vector `<1.0, 1.0/256.0, 1.0/65536.0, 0.0>`
+  /// The RGB higher quality depth vector `<1.0, 1.0/256.0, 1.0/65536.0, 0.0>`
   /// which is the default for shadow depth adjustment.
   static Vector4 get shadowAdjust {
     _shadowAdjust ??= new Vector4(1.0, 1.0/256.0, 1.0/65536.0, 0.0);

--- a/lib/src/Shaders/ColorSourceType.dart
+++ b/lib/src/Shaders/ColorSourceType.dart
@@ -3,7 +3,7 @@ part of ThreeDart.Shaders;
 /// A description of what kind of source the color comes from.
 class ColorSourceType {
   
-  /// Indicates that the source color has a solid value such as a float or RBG color.
+  /// Indicates that the source color has a solid value such as a float or RGB color.
   final bool hasSolid;
 
   /// Indicates that the source color comes from a 2D texture.

--- a/lib/src/Shaders/MaterialLightFS.dart
+++ b/lib/src/Shaders/MaterialLightFS.dart
@@ -586,13 +586,12 @@ class _materialLightFS {
     buf.writeln("   float zScale = dot(normDir, lit.objDir);");
     buf.writeln("   if(zScale < 0.0) return vec3(0.0, 0.0, 0.0);");
     if (light.hasCutOff) {
-      // TODO: On some Mac's `acos` doesn't work correctly. We should probably
-      // add some kind of switch to allow adjustments based on environment differences.
-      // Until then use `atan` to get the angle instead of `acos`.
-      buf.writeln("   float crossMag = length(cross(normDir, lit.objDir));");
-      buf.writeln("   float angle = atan(crossMag, zScale);");
-      // buf.writeln("   float angle = acos(zScale);");
-
+      // On some Mac's `acos` doesn't work correctly so use the `atan` equivalent.
+      if (Core.Environment.os == Core.OperatingSystem.mac) {
+        buf.writeln("   float crossMag = length(cross(normDir, lit.objDir));");
+        buf.writeln("   float angle = atan(crossMag, zScale);");
+      } else
+        buf.writeln("   float angle = acos(zScale);");
       buf.writeln("   float scale = (lit.cutoff-angle) / (lit.cutoff-lit.coneAngle);");
       buf.writeln("   if(scale <= 0.0) return vec3(0.0, 0.0, 0.0);");
       buf.writeln("   if(scale >= 1.0) scale = 1.0;");

--- a/lib/src/Shaders/MaterialLightFS.dart
+++ b/lib/src/Shaders/MaterialLightFS.dart
@@ -586,7 +586,13 @@ class _materialLightFS {
     buf.writeln("   float zScale = dot(normDir, lit.objDir);");
     buf.writeln("   if(zScale < 0.0) return vec3(0.0, 0.0, 0.0);");
     if (light.hasCutOff) {
-      buf.writeln("   float angle = acos(zScale);");
+      // TODO: On some Mac's `acos` doesn't work correctly. We should probably
+      // add some kind of switch to allow adjustments based on environment differences.
+      // Until then use `atan` to get the angle instead of `acos`.
+      buf.writeln("   float crossMag = length(cross(normDir, lit.objDir));");
+      buf.writeln("   float angle = atan(crossMag, zScale);");
+      // buf.writeln("   float angle = acos(zScale);");
+
       buf.writeln("   float scale = (lit.cutoff-angle) / (lit.cutoff-lit.coneAngle);");
       buf.writeln("   if(scale <= 0.0) return vec3(0.0, 0.0, 0.0);");
       buf.writeln("   if(scale >= 1.0) scale = 1.0;");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ThreeDart
-version: 0.1.0
+version: 0.1.1
 description: 3D graphical rendering tool for websites written in Dart.
 environment:
   sdk: '>=2.0.0'

--- a/web/tests/test027/test.dart
+++ b/web/tests/test027/test.dart
@@ -82,7 +82,7 @@ void main() {
                                 });
                               })
     ..add("Cylinder",      () { secondObj.shape = Shapes.cylinder(sides: 30); })
-    ..add("Cone",          () { secondObj.shape = Shapes.cylinder(topRadius: 0.0, sides: 30, capTop: false); })
+    ..add("Cone",          () { secondObj.shape = Shapes.cylinder(topRadius: 0.0, sides: 30, div: 5, capTop: false); })
     ..add("Cylindrical",   () { secondObj.shape = Shapes.cylindrical(sides: 50, div: 25,
                                 radiusHndl: (double u, double v) => cos(v*4.0*Math.PI + Math.PI)*0.2 + cos(u*6.0*Math.PI)*0.3 + 0.8); })
     ..add("Sphere",        () { secondObj.shape = Shapes.sphere(widthDiv: 6, heightDiv: 6); })

--- a/web/tests/test048/test.dart
+++ b/web/tests/test048/test.dart
@@ -12,8 +12,9 @@ import '../../common/common.dart' as common;
 void main() {
   common.ShellPage page = new common.ShellPage("Test 048")
     ..addLargeCanvas("testCanvas")
-    ..addPar(["Test of the Material Lighting shader with multiple moving point lights. ",
-      "Emissive spheres are added at the lights sources."])
+    ..addPar(["Test of the Material Lighting shader with a bar light. ",
+      "The bar light hasn't been finished yet so this test is more of a ",
+      "testbed for it's development."])
     ..addControlBoxes(["shapes"])
     ..addPar(["«[Back to Tests|../]"]);
 


### PR DESCRIPTION
# Issue [#130](https://github.com/Grant-Nelson/ThreeDart/issues/130) and [#129](https://github.com/Grant-Nelson/ThreeDart/issues/129)

## Bugs/Problems

- Figure out and fix the scroll wheel zoom speed on Mozilla
- The spotlight doesn't work on Chrome on Macs. Figure out what is wrong and fix it without breaking it on Windows. Should also check on Chrome and Mozilla.

## Implementation

- Bump the copyright year
- Bump the version number
- Added Environment which lets us determine the browser and OS
- Fixed the problem with the scroll wheel zoom on Firefox by changing the scroll wheel scalar if the browser type is Firefox
- Fixed the spotlight on Macs by having the glsl shader for spotlight not use `acos` which appears to have issues but instead use an `atan` equivalent
- Fixed some spelling
- Fixed a test 48 description

## Review and Testing

- [x] Check Firefox and Chrome on Windows and Mac
- [x] Check spotlight and textured spotlight
- [x] Check scroll wheel on speed on several tests
- [x] Check the unit-tests
